### PR TITLE
Docker config for getting started quickly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM tomcat:9.0
+MAINTAINER Evolved Binary
+
+COPY opentheso2-21.02.war /usr/local/tomcat/webapps/opentheso2.war
+
+RUN mkdir /usr/local/tomcat/webapps/opentheso2 \
+	&& unzip -d /usr/local/tomcat/webapps/opentheso2/ /usr/local/tomcat/webapps/opentheso2.war \
+	&& mkdir -p /var/www/images/resize
+
+
+# Modify the config for Opentheso
+COPY preferences.properties /usr/local/tomcat/webapps/opentheso2/WEB-INF/classes/
+COPY hikari.properties /usr/local/tomcat/webapps/opentheso2/WEB-INF/classes/

--- a/docker/Dockerfile-postgres
+++ b/docker/Dockerfile-postgres
@@ -1,0 +1,9 @@
+FROM postgres
+MAINTAINER Evolved Binary
+
+# Copy in the Opentheso database setup scripts
+ADD https://raw.githubusercontent.com/miledrousset/Opentheso2/master/src/main/resources/install/opentheso_current.sql /docker-entrypoint-initdb.d/01-opentheso_current.sql
+ADD https://raw.githubusercontent.com/miledrousset/Opentheso2/master/src/main/resources/install/maj_bdd_current2.sql /docker-entrypoint-initdb.d/02-maj_bdd_current2.sql
+
+RUN chmod 744 /docker-entrypoint-initdb.d/01-opentheso_current.sql \
+	&& chmod 744 /docker-entrypoint-initdb.d/02-maj_bdd_current2.sql

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,56 @@
+# Building the Docker Image
+
+The configuration for two Docker Images are provided; one image for Opentheso2 itself, and the other for a Postgres database which holds the Opentheso2 data. 
+
+```
+docker image build -t miledrousset/opentheso2-postgres -f Dockerfile-postgres .
+
+docker image build -t miledrousset/opentheso2 .
+```
+
+
+# Running the Docker Containers
+
+There are two options for running the Docker Containers:
+1. Using Docker Compose to manage the containers for you
+2. Using Docker directly to start each container
+
+Pre-requisites:
+1. Docker
+2. Place a copy of `opentheso2-21.02.war` in the `opentheso2/docker` directory.
+
+
+## Running via Docker Compose
+
+Simply execute:
+
+```
+cd opentheso2/docker
+
+docker compose up
+```
+
+## Running directly with Docker
+
+A Docker Container for the Opentheso2 Posgres database must be started before starting a container for Opentheso22 itself.
+
+```
+cd opentheso2/docker
+
+docker run --name opentheso2-db --volume opentheso2-pgdata:/pgdata --env POSTGRES_USER=opentheso --env POSTGRES_PASSWORD=opentheso --env PGDATA=/pgdata miledrousset/opentheso2-postgres
+
+docker run --name opentheso2 --link opentheso2-db --publish 8080:8080 -it miledrousset/opentheso2
+```
+
+## Accessing Opentheso2
+
+Once the Docker Containers are running, you can access Opentheso2 in a web-browser by visiting: http://localhost:8080/opentheso2
+
+
+# Docker Volumes
+
+The docker volume `opentheso2-pgdata` stores the database, if you want to start with a clean slate you can remove the volume and it will be re-created. To remove the volume just run:
+
+```
+docker volume rm opentheso2-pgdata
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.1'
+
+services:
+
+  opentheso:
+    image: miledrousset/opentheso2
+    restart: always
+    depends_on:
+      - opentheso2-db
+    ports:
+      - 8080:8080
+
+  opentheso2-db:
+    image: miledrouset/opentheso2-postgres
+    restart: always
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: opentheso
+      POSTGRES_PASSWORD: opentheso
+      PGDATA: /pgdata
+    volumes:
+      - type: volume
+        source: opentheso2-pgdata
+        target: /pgdata
+
+volumes:
+  opentheso-pgdata:
+    external: false

--- a/docker/hikari.properties
+++ b/docker/hikari.properties
@@ -1,0 +1,13 @@
+minimumIdle=1
+autoCommit=true
+setMaximumPoolSize=1000
+idleTimeout=30000
+connectionTimeout=30000
+connectionTestQuery=SELECT 1
+dataSourceClassName=org.postgresql.ds.PGSimpleDataSource
+
+dataSource.serverName=opentheso2-db
+dataSource.serverPort=5432
+dataSource.user=opentheso
+dataSource.password=opentheso
+dataSource.databaseName=opentheso

--- a/docker/preferences.properties
+++ b/docker/preferences.properties
@@ -1,0 +1,15 @@
+#Preferred language
+workLanguage=en
+
+#l'identifiant du th\u00e9saurus par d\u00e9faut \u00e0 charger
+defaultThesaurusId=TH_1
+
+timeout_nbr_minute=29
+
+#Serveur de mail pour les alertes du module candidats
+protocolMail=smtp
+hostMail=smtp.mom.fr
+portMail=25
+authMail=false
+mailFrom=opentheso@mom.fr
+transportMail=smtp


### PR DESCRIPTION
This is the counterpart to https://github.com/miledrousset/opentheso/pull/17 but adjusted slightly for Opentheso2.

---

This provides the necessary Docker files and Docker Compose config, so that getting started with Opentheso2 can be as simple as:

```
git clone https://github.com/miledrousset/opentheso2.git
cd opentheso2/docker

wget https://github.com/miledrousset/Opentheso2/releases/download/21.02/opentheso2-21.02.war

docker image build -t miledrousset/opentheso2-postgres -f Dockerfile-postgres .
docker image build -t miledrousset/opentheso2 .

docker compose up
```

After which both Postgres and Opentheso2 are now running in Docker and the user can just access http://localhost:8080/opentheso2

I have supplied documentation also in the `docker/README.md` file. Apologies as my French language skills are not good enough to help translate the instructions into French.

---
This could be improved further in future if desired by:
1. Fixing the Maven build. At present `mvn package` fails.
2. Adding the fabric8 Docker Maven Plugin to the `pom.xml` to help generate the Dockerfiles and Compose config.
3. For each release, Publish the Docker images to Docker Hub so the user does not need to build anything themselves, and could just run the single `docker compose up` command.